### PR TITLE
Throw InvalidNumberException for a null String.

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/util/PhoneNumberFormatter.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/util/PhoneNumberFormatter.java
@@ -66,6 +66,10 @@ public class PhoneNumberFormatter {
   public static String formatNumber(String number, String localNumber)
       throws InvalidNumberException
   {
+    if (number == null) {
+      throw new InvalidNumberException("Null String passed as number.");
+    }
+
     if (number.contains("@")) {
       throw new InvalidNumberException("Possible attempt to use email address.");
     }


### PR DESCRIPTION
This is intended to fix WhisperSystems/Signal-Android#5639. Any fixes
inside the Android project felt like a band-aid.
