### PR TITLE
Add missing close()

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
@@ -173,8 +173,7 @@ public class AttachmentCipherInputStream extends FileInputStream {
   }
 
   private void verifyMac(File file, Mac mac) throws FileNotFoundException, InvalidMacException {
-    try {
-      FileInputStream fin           = new FileInputStream(file);
+    try (FileInputStream fin = new FileInputStream(file)) {
       int             remainingData = Util.toIntExact(file.length()) - mac.getMacLength();
       byte[]          buffer        = new byte[4096];
 


### PR DESCRIPTION
verifyMac() creates its own FileInputStream, but doesn't close it.

Without closing the input stream, the file cannot be deleted on Windows.
See https://github.com/AsamK/signal-cli/issues/32#issuecomment-263137799