### PR TITLE
Catch & encapsulate RateLimitExceptions on send

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/push/exceptions/EncapsulatedExceptions.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/push/exceptions/EncapsulatedExceptions.java
@@ -15,20 +15,24 @@ public class EncapsulatedExceptions extends Throwable {
   private final List<UntrustedIdentityException> untrustedIdentityExceptions;
   private final List<UnregisteredUserException>  unregisteredUserExceptions;
   private final List<NetworkFailureException>    networkExceptions;
+  private final List<RateLimitExceededException> rateLimitExceptions;
 
   public EncapsulatedExceptions(List<UntrustedIdentityException> untrustedIdentities,
                                 List<UnregisteredUserException> unregisteredUsers,
-                                List<NetworkFailureException> networkExceptions)
+                                List<NetworkFailureException> networkExceptions,
+                                List<RateLimitExceededException> rateLimitExceptions)
   {
     this.untrustedIdentityExceptions = untrustedIdentities;
     this.unregisteredUserExceptions  = unregisteredUsers;
     this.networkExceptions           = networkExceptions;
+    this.rateLimitExceptions         = rateLimitExceptions;
   }
 
   public EncapsulatedExceptions(UntrustedIdentityException e) {
     this.untrustedIdentityExceptions = new LinkedList<>();
     this.unregisteredUserExceptions  = new LinkedList<>();
     this.networkExceptions           = new LinkedList<>();
+    this.rateLimitExceptions         = new LinkedList<>();
 
     this.untrustedIdentityExceptions.add(e);
   }
@@ -43,5 +47,9 @@ public class EncapsulatedExceptions extends Throwable {
 
   public List<NetworkFailureException> getNetworkExceptions() {
     return networkExceptions;
+  }
+
+  public List<RateLimitExceededException> getRateLimitExceptions() {
+    return rateLimitExceptions;
   }
 }

--- a/java/src/main/java/org/whispersystems/signalservice/api/push/exceptions/RateLimitExceededException.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/push/exceptions/RateLimitExceededException.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2014-2017 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+package org.whispersystems.signalservice.api.push.exceptions;
+
+public class RateLimitExceededException extends Exception {
+
+  private final String e164number;
+
+  public RateLimitExceededException(String e164number, Exception nested) {
+    super(nested);
+    this.e164number = e164number;
+  }
+
+  public String getE164number() {
+    return e164number;
+  }
+}


### PR DESCRIPTION
Repeatedly requesting prekeys for unregistered group members can lead to RateLimitExceptions, making the send job fail and leading to 4 retries. If that happens, those who precede the unregistered user in the list of group members receive the message 5 times, while the others don't receive it at all.

To work around this, catch and encapsulate RateLimitExceptions and rethrow them at the end, just like with PushNetworkExceptions, UnregisteredUserExceptions, and UntrustedIdentityExceptions.

Fixes WhisperSystems/Signal-Android#6003 (tested in an API 23 emulator)

---

Note: I copied the pattern of `NetworkFailureException` wrapping `PushNetworkException` here, so `RateLimitExceededException` wraps `RateLimitException`. Not sure if the name is good, but I wanted to include the recipient's number in case it's needed later.