### PR TITLE
Introduce `fetchesMessages` to `AccountAttributes`

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceAccountManager.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceAccountManager.java
@@ -118,12 +118,12 @@ public class SignalServiceAccountManager {
    *
    * @throws IOException
    */
-  public void verifyAccountWithCode(String verificationCode, String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video)
+  public void verifyAccountWithCode(String verificationCode, String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video, boolean fetchesMessages)
       throws IOException
   {
     this.pushServiceSocket.verifyAccountCode(verificationCode, signalingKey,
                                              signalProtocolRegistrationId,
-                                             voice, video);
+                                             voice, video, fetchesMessages);
   }
 
   /**
@@ -141,10 +141,10 @@ public class SignalServiceAccountManager {
    *
    * @throws IOException
    */
-  public void verifyAccountWithToken(String verificationToken, String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video)
+  public void verifyAccountWithToken(String verificationToken, String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video, boolean fetchesMessages)
       throws IOException
   {
-    this.pushServiceSocket.verifyAccountToken(verificationToken, signalingKey, signalProtocolRegistrationId, voice, video);
+    this.pushServiceSocket.verifyAccountToken(verificationToken, signalingKey, signalProtocolRegistrationId, voice, video, fetchesMessages);
   }
 
   /**
@@ -159,10 +159,10 @@ public class SignalServiceAccountManager {
    *
    * @throws IOException
    */
-  public void setAccountAttributes(String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video)
+  public void setAccountAttributes(String signalingKey, int signalProtocolRegistrationId, boolean voice, boolean video, boolean fetchesMessages)
       throws IOException
   {
-    this.pushServiceSocket.setAccountAttributes(signalingKey, signalProtocolRegistrationId, voice, video);
+    this.pushServiceSocket.setAccountAttributes(signalingKey, signalProtocolRegistrationId, voice, video, fetchesMessages);
   }
 
   /**

--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/AccountAttributes.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/AccountAttributes.java
@@ -22,11 +22,15 @@ public class AccountAttributes {
   @JsonProperty
   private boolean video;
 
-  public AccountAttributes(String signalingKey, int registrationId, boolean voice, boolean video) {
+  @JsonProperty
+  private boolean fetchesMessages;
+
+  public AccountAttributes(String signalingKey, int registrationId, boolean voice, boolean video, boolean fetchesMessages) {
     this.signalingKey   = signalingKey;
     this.registrationId = registrationId;
     this.voice          = voice;
     this.video          = video;
+    this.fetchesMessages = fetchesMessages;
   }
 
   public AccountAttributes() {}
@@ -45,5 +49,9 @@ public class AccountAttributes {
 
   public boolean isVideo() {
     return video;
+  }
+
+  public boolean isFetchesMessages() {
+    return fetchesMessages;
   }
 }

--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -130,24 +130,24 @@ public class PushServiceSocket {
     makeRequest(String.format(path, credentialsProvider.getUser()), "GET", null);
   }
 
-  public void verifyAccountCode(String verificationCode, String signalingKey, int registrationId, boolean voice, boolean video)
+  public void verifyAccountCode(String verificationCode, String signalingKey, int registrationId, boolean voice, boolean video, boolean fetchesMessages)
       throws IOException
   {
-    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, registrationId, voice, video);
+    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, registrationId, voice, video, fetchesMessages);
     makeRequest(String.format(VERIFY_ACCOUNT_CODE_PATH, verificationCode),
                 "PUT", JsonUtil.toJson(signalingKeyEntity));
   }
 
-  public void verifyAccountToken(String verificationToken, String signalingKey, int registrationId, boolean voice, boolean video)
+  public void verifyAccountToken(String verificationToken, String signalingKey, int registrationId, boolean voice, boolean video, boolean fetchesMessages)
       throws IOException
   {
-    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, registrationId, voice, video);
+    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, registrationId, voice, video, fetchesMessages);
     makeRequest(String.format(VERIFY_ACCOUNT_TOKEN_PATH, verificationToken),
                 "PUT", JsonUtil.toJson(signalingKeyEntity));
   }
 
-  public void setAccountAttributes(String signalingKey, int registrationId, boolean voice, boolean video) throws IOException {
-    AccountAttributes accountAttributes = new AccountAttributes(signalingKey, registrationId, voice, video);
+  public void setAccountAttributes(String signalingKey, int registrationId, boolean voice, boolean video, boolean fetchesMessages) throws IOException {
+    AccountAttributes accountAttributes = new AccountAttributes(signalingKey, registrationId, voice, video, fetchesMessages);
     makeRequest(SET_ACCOUNT_ATTRIBUTES, "PUT", JsonUtil.toJson(accountAttributes));
   }
 


### PR DESCRIPTION
Create the field `fetchesMessages` in the class `AccountAttributes`,
add the appropriate parameters to the constructor, and implement a
'getting'.

The functionality for a device to retrieve its own messages is already
implemented on the server but we have no way of accessing it.

Alongside this minimal change is a collection of modifications so that
methods that make use of `AccountAttributes` still do so correctly.

Signed-off-by: Alex Melbourne <alex.melbourne@protonmail.com>