### PR TITLE
fix unnecessary threadpool-creation

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -77,6 +77,7 @@ import okhttp3.Response;
 public class PushServiceSocket {
 
   private static final String TAG = PushServiceSocket.class.getSimpleName();
+  private static final OkHttpClient CLIENT = new OkHttpClient();
 
   private static final String CREATE_ACCOUNT_SMS_PATH   = "/v1/accounts/sms/code/%s";
   private static final String CREATE_ACCOUNT_VOICE_PATH = "/v1/accounts/voice/code/%s";
@@ -612,7 +613,7 @@ public class PushServiceSocket {
       SSLContext context = SSLContext.getInstance("TLS");
       context.init(null, trustManagers, null);
 
-      OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
+      OkHttpClient.Builder okHttpClientBuilder = CLIENT.newBuilder()
           .sslSocketFactory(context.getSocketFactory(), (X509TrustManager)trustManagers[0])
           .connectTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS)
           .readTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
New OkHttpClients came with their own thread and connection pools. With newBuilder() we can create a new client with an already existing pool.

Fixes https://github.com/WhisperSystems/Signal-Android/issues/6283


See https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html for more information.