### PR TITLE
Allow user to define keepalive time interval.

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
@@ -118,7 +118,21 @@ public class SignalServiceMessageReceiver {
    * @return A SignalServiceMessagePipe for receiving Signal Service messages.
    */
   public SignalServiceMessagePipe createMessagePipe() {
+    return createMessagePipe(WebSocketConnection.DEFAULT_KEEPALIVE_TIMEOUT_SECONDS);
+  }
+
+  /**
+   * Creates a pipe for receiving SignalService messages.
+   *
+   * Callers must call {@link SignalServiceMessagePipe#shutdown()} when finished with the pipe.
+   *
+   * @param kaTimeoutSeconds The number of seconds between sending keepalive messages
+   *
+   * @return A SignalServiceMessagePipe for receiving Signal Service messages.
+   */
+  public SignalServiceMessagePipe createMessagePipe(int kaTimeoutSeconds) {
     WebSocketConnection webSocket = new WebSocketConnection(urls[0].getUrl(), urls[0].getTrustStore(), credentialsProvider, userAgent);
+    webSocket.setKeepAliveTimeoutSeconds(kaTimeoutSeconds);
     return new SignalServiceMessagePipe(webSocket, credentialsProvider);
   }
 


### PR DESCRIPTION
The keepalive interval is hardcoded to 55 seconds. This is the same as the connection timeout on Heroku (https://devcenter.heroku.com/articles/request-timeout#long-polling-and-streaming-responses).

This means that connections sometimes timeout unnecessarily because the keepalive intervals are too large. This PR allows a developer to set their own keepalive intervals.