### PR TITLE
Added the ability to "prod" the WebSocketConnection

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessagePipe.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessagePipe.java
@@ -160,6 +160,10 @@ public class SignalServiceMessagePipe {
     websocket.disconnect();
   }
 
+  public static void prod() {
+    WebSocketConnection.Prod.use();
+  }
+
   private boolean isSignalServiceEnvelope(WebSocketRequestMessage message) {
     return "PUT".equals(message.getVerb()) && "/api/v1/message".equals(message.getPath());
   }

--- a/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
@@ -41,7 +41,7 @@ import static org.whispersystems.signalservice.internal.websocket.WebSocketProto
 public class WebSocketConnection extends WebSocketListener {
 
   private static final String TAG                       = WebSocketConnection.class.getSimpleName();
-  private static final int    KEEPALIVE_TIMEOUT_SECONDS = 55;
+  private static final int    KEEPALIVE_TIMEOUT_SECONDS = 60;
 
   private final LinkedList<WebSocketRequestMessage>              incomingRequests = new LinkedList<>();
   private final Map<Long, SettableFuture<Pair<Integer, String>>> outgoingRequests = new HashMap<>();
@@ -225,12 +225,25 @@ public class WebSocketConnection extends WebSocketListener {
       keepAliveSender = null;
     }
 
-    Util.wait(this, Math.min(++attempts * 200, TimeUnit.SECONDS.toMillis(15)));
-
     if (client != null) {
       client.close(1000, "OK");
       client    = null;
       connected = false;
+
+      long timeoutMillis = 200 * (1 << Math.min(attempts++, 10)), thresholdMillis = TimeUnit.SECONDS.toMillis(15);
+
+      if (timeoutMillis < thresholdMillis) {
+        long startTime = System.currentTimeMillis();
+
+        Log.w(TAG, "Busy-waiting for " + timeoutMillis + " millis prior to reconnecting.");
+
+        while (elapsedTime(startTime) < timeoutMillis);
+      } else {
+        Log.w(TAG, "Block-waiting for " + thresholdMillis + " millis prior to reconnecting.");
+
+        Util.wait(this, thresholdMillis);
+      }
+
       connect();
     }
 
@@ -274,17 +287,41 @@ public class WebSocketConnection extends WebSocketListener {
     }
   }
 
+  public static class Prod {
+    private static boolean active = false;
+
+    public static synchronized void use() {
+      active = true;
+
+      Prod.class.notifyAll();
+    }
+
+    private static synchronized boolean waitForProdOrTimeout(long millis) {
+      Util.wait(Prod.class, active ? 0 : millis);
+
+      return active;
+    }
+  }
+
   private class KeepAliveSender extends Thread {
 
     private AtomicBoolean stop = new AtomicBoolean(false);
 
     public void run() {
-      while (!stop.get()) {
+      while (true) {
         try {
-          Thread.sleep(TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS));
+          if (Prod.waitForProdOrTimeout(TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS))) {
+            synchronized(WebSocketConnection.this) {
+              WebSocketConnection.this.notifyAll();
+            }
+          }
 
-          Log.w(TAG, "Sending keep alive...");
-          sendKeepAlive();
+          if (stop.get()) {
+            break;
+          } else {
+            Log.w(TAG, "Sending keep alive...");
+            sendKeepAlive();
+          }
         } catch (Throwable e) {
           Log.w(TAG, e);
         }


### PR DESCRIPTION
Adds a method to the `SignalServiceMessagePipe`, that can be called
periodically, in order to avoid issues when the device enters sleep,
disrupting timing functions like `Thread.sleep()` and `Object.wait()`.

// FREEBIE

### The Problem

This pull request is part of a solution to issue WhisperSystems/Signal-Android#6644.  The problem is that when the device enters sleep mode (basically as soon as the power button is pressed, provided no wake locks are held), the `uptimeMillis()` clock [on which most interval timing functions such as `Thread.sleep(millls)` and `Object.wait(millis)` depend](https://developer.android.com/reference/android/os/SystemClock.html) stops ticking.

The result is that WebSocket-handling code, that performs blocking wait, never awakes as the timeout never expires.  This seems to be of no consequence on GCM-enabled devices, as the GCM notification wakes the device, which afterwards acquires a wake lock, until the message is received, but can make the application unusable when GCM is not available.

Note though, that it does happen in the presence of GCM as well:  When the wake-lock is released and the device falls asleep (after any messages have been processed), return from `readRequest()` can be delayed indefinitely and hold the socket open.  The keep alive is also missed and the socket is closed with an `EOFException`.  I'm not sure whether this can have any practical effect on the overall operation of the application though.  In any case, the solution proposed below can work with GCM-enabled devices as well, if deemed necessary.

This problem arises in three cases:

1. When waiting to issue the next keep alive inside `KeepAliveSender`'s thread:  Here the typical result is that keep-alives are missed, as soon as the device falls asleep and the socket closes soon afterwards.  Reception of any messages arriving after that, is delayed for an indefinite amount of time, typically until the user wakes the device (or until some other process wakes the device, long enough for the timeout to expire).

2. When blocking while waiting for the data to become available on the socket:  As far as I can see, the only result of any consequence here, is that the shutdown of the pipe corresponding to the socket can be delayed indefinitely.  I'm not sure whether this can have any adverse effects on operation.

3. When blocking after a disconnection and before attempting to reconnect:  This has the obvious consequence that reconnection, say after a socket error, can be delayed indefinitely, possibly leading to connectivity issues.

### The attempted solution

The solution, or at least the half that concerns the socket, is to provide a method to jolt the socket-related threads out of sleep periodically (called "proding" the pipe/socket).  Note that this is *not* the same as polling:  The prod only substitutes for the expiration of `Thread.sleep()` and `Object.wait()`, which will never come.  The basic nature of the operation of the socket, remains unchanged.

The only essential purpose of the prod, is to wake the `KeepAliveSender`'s thread and ensure delivery of the keep-alive.  The approach is to substitute the call to `Thread.sleep()`, with a `wait()` on a lock, that is global to all threads.  Each time the socket is prodded, `notifyAll()` is called on the lock and the threads awake.  This approach nicely accommodates the possibility of more than one sockets co-existing at any one time.

When the  `KeepAliveSender`'s thread awakens from a prod, it also `notifyAll()`s the `WebSocketConnection`, in order to make sure it's not stuck blocking in `readRequest()` or `onClosed()`.  Since the prods will practically arrive 1 minute apart, we cannot depend on them to wake us when blocking before a reconnection, so this wait, has been converted to a hybrid approach, where the first few attempts are busy-waits, to ensure a fast reconnection.  The wait has also been moved, so as to only occur when a reconnection will follow.  It therefore has practically no effect on GCM-enabled devices, which generally won't need to reconnect very often, as they close the pipe after each operation is concluded.
